### PR TITLE
Fix GitHub Actions checks and critical model.R bug

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,16 +28,16 @@ jobs:
         config:
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-20.04,   r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", http-user-agent: "R/4.0.0 (ubuntu-20.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }
-          # - {os: ubuntu-20.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-          # - {os: ubuntu-20.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+          - {os: ubuntu-latest,   r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest", http-user-agent: "R/4.0.0 (ubuntu-latest) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }
+          # - {os: ubuntu-latest,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"}
+          # - {os: ubuntu-latest,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"}
 
     env:
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         id: install-r
@@ -54,7 +54,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Restore R package cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.R_LIBS_USER }}/*
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.config.os }}-r${{ matrix.config.r }}-results
           path: check

--- a/pkg/criticality/R/model.R
+++ b/pkg/criticality/R/model.R
@@ -85,4 +85,6 @@ Model <- function(
       metrics = c('mean_absolute_error'))
   }
 
+  return(model)
+
 }


### PR DESCRIPTION
This commit fixes two main issues:

1. Fixed missing return statement in Model() function (pkg/criticality/R/model.R)
   - Added return(model) at line 88
   - Previously the function was returning NULL instead of the compiled model
   - This bug would cause failures in NN() and other functions that depend on Model()

2. Updated GitHub Actions workflow to use current versions
   - Updated actions/checkout from v2 to v4
   - Updated actions/cache from v2 to v4
   - Updated actions/upload-artifact from main to v4
   - Updated Ubuntu runner from ubuntu-20.04 to ubuntu-latest
   - Updated package manager URL from bionic to jammy